### PR TITLE
fix parse range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.0.5 / 2023-08-04
+- Changed
+    - Fixed parse-range
+
 0.0.4 / 2022-12-23
 ------------------
 - Changed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the first example below we pull data from a specific sheet within the workboo
 #!/usr/bin/env bb
 (require '[babashka.deps :as deps])
 (deps/add-deps 
-  '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.4"}}}) 
+  '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.5"}}}) 
 
 (ns demo
   (:require [clojure.pprint :refer [print-table pprint]]

--- a/bb-excel
+++ b/bb-excel
@@ -2,7 +2,7 @@
 
 (require '[babashka.deps :as deps])
 
-(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.4"}}})
+(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.5"}}})
 
 (ns bb-excel
   (:require [bb-excel.core     :refer [get-sheets get-range get-sheet]]
@@ -115,7 +115,7 @@
 (defn help
   "Command line options"
   [summary]
-  (->> ["bb-excel 0.0.4"
+  (->> ["bb-excel 0.0.5"
         ""
         "Usage: bb-excel input-file options"
         ""

--- a/bbexcel
+++ b/bbexcel
@@ -2,7 +2,7 @@
 
 (require '[babashka.deps :as deps])
 
-(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.4"}}})
+(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.5"}}})
 
 (ns bbexcel
   (:require [bb-excel.core     :refer [get-sheets get-range get-sheet]]
@@ -115,7 +115,7 @@
 (defn help
   "Command line options"
   [summary]
-  (->> ["bbexcel 0.0.4"
+  (->> ["bbexcel 0.0.5"
         ""
         "Usage: bbexcel input-file options"
         ""

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.kbosompem/bb-excel "0.0.4"
+(defproject com.github.kbosompem/bb-excel "0.0.5"
   :description "A Simple Clojure/Babashka Library for Reading Data from Excel Files"
   :url "https://github.com/kbosompem/bb-excel"
   :license {:name "EPL-2.0"

--- a/src/bb_excel/core.clj
+++ b/src/bb_excel/core.clj
@@ -249,7 +249,7 @@
 (defn parse-range
   "Takes in an Excel coordinate and returns a hashmap of rows and columns to pull"
   [s]
-  (let [[[_ osc osr oec oer]] (re-seq #"([A-Z]+)([1-9]*)[:]?([A-Z]*)([1-9]*)" s)
+  (let [[[_ osc osr oec oer]] (re-seq #"([A-Z]+)([0-9]*)[:]?([A-Z]*)([0-9]*)" s)
         sc (or osc "A")
         ec (or (when-str oec) (when-str osc) sc)
         sr (or (when-num osr) 1)

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -34,7 +34,9 @@
     (is (nil? (get-sheet-names "missingfile.xlsx"))
         "File does not exist. Should return null.")
     (is (nil? (get-sheet-names nil))
-        "Filename was not passed in")))
+        "Filename was not passed in")
+    (is (= '({:_r 10 :A "9" :B "TextData"})
+            (get-range (get-sheet "test/data/Types.xlsx" "Sheet1") "A10:B10")))))
 
 (comment
   (run-tests)


### PR DESCRIPTION
Fixing a problem where whenever range has 0 in it the parse-range fails to correctly locate the rows.