### PR TITLE
Respect files without styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ------------------
 - Changed
     - Fix parse xlsx without xl/styles.xml
-    - Refactoring
+    - Refactoring and optimizations
 
 0.0.7 / 2023-10-27
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+0.0.8 / 2023-11-03
+------------------
+- Changed
+    - Fix parse xlsx without xl/styles.xml
+    - Refactoring
+
 0.0.7 / 2023-10-27
 ------------------
 - Changed
-  - Fix parse xlsx without xl/sharedStrings.xml
-  - Fix parse cell with number and inlineStr data types
+    - Fix parse xlsx without xl/sharedStrings.xml
+    - Fix parse cell with number and inlineStr data types
 
 0.0.6 / 2023-09-16
 ------------------

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the first example below we pull data from a specific sheet within the workboo
 #!/usr/bin/env bb
 (require '[babashka.deps :as deps])
 (deps/add-deps 
-  '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.6"}}})
+  '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.8"}}})
 
 (ns demo
   (:require [clojure.java.io :as io]

--- a/bb-excel
+++ b/bb-excel
@@ -2,7 +2,7 @@
 
 (require '[babashka.deps :as deps])
 
-(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.6"}}})
+(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.8"}}})
 
 (ns bb-excel
   (:require [bb-excel.core     :refer [get-sheets get-range get-sheet]]
@@ -115,7 +115,7 @@
 (defn help
   "Command line options"
   [summary]
-  (->> ["bb-excel 0.0.6"
+  (->> ["bb-excel 0.0.8"
         ""
         "Usage: bb-excel input-file options"
         ""

--- a/bbexcel
+++ b/bbexcel
@@ -2,7 +2,7 @@
 
 (require '[babashka.deps :as deps])
 
-(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.6"}}})
+(deps/add-deps '{:deps {com.github.kbosompem/bb-excel {:mvn/version "0.0.8"}}})
 
 (ns bbexcel
   (:require [bb-excel.core     :refer [get-sheets get-range get-sheet]]
@@ -115,7 +115,7 @@
 (defn help
   "Command line options"
   [summary]
-  (->> ["bbexcel 0.0.6"
+  (->> ["bbexcel 0.0.8"
         ""
         "Usage: bbexcel input-file options"
         ""

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.kbosompem/bb-excel "0.0.7"
+(defproject com.github.kbosompem/bb-excel "0.0.8"
   :description "A Simple Clojure/Babashka Library for Reading Data from Excel Files"
   :url "https://github.com/kbosompem/bb-excel"
   :license {:name "EPL-2.0"


### PR DESCRIPTION
@kbosompem Hi. I started making a fix for the case where parsing file with missing "r" cell attributes. Like it [described here](https://github.com/box/spout/issues/267) for project like bb-excel but for PHP. But i can't finish it without some refactoring. Therefore, I first decided to fix a small problem where the style file was missing and did a small refactoring in it. At the same time, I’ll find out how you feel about refactoring. If you upload PR, please use squash&merge. Have a good day.